### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-version-branch.yml
+++ b/.github/workflows/ci-version-branch.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/unstoppable-wallet-android/security/code-scanning/3](https://github.com/Wbaker7702/unstoppable-wallet-android/security/code-scanning/3)

In general, the fix is to explicitly define a `permissions:` block so the `GITHUB_TOKEN` is limited to the minimum scope required by this workflow. Since the job only needs to read the repository contents (for checkout and build), a safe minimal permission is `contents: read` at the job or workflow level.

The best minimal fix without changing existing functionality is to add a `permissions:` block under the `build` job in `.github/workflows/ci-version-branch.yml`. This will apply only to that job and avoid affecting other workflows. Place it alongside `runs-on`, at the same indentation level, for example:

```yaml
jobs:
  build:
    runs-on: ubuntu-latest
    permissions:
      contents: read
```

No additional imports, methods, or external dependencies are needed; this is a pure YAML configuration change inside the Actions workflow file. All existing steps (checkout, Ruby setup, Java setup, environment variable calculation, Fastlane invocation) will continue to work, while the `GITHUB_TOKEN` will now be restricted to read-only access to repository contents for this job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration permissions for the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->