### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,5 +1,8 @@
 name: Android CI (release)
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/unstoppable-wallet-android/security/code-scanning/2](https://github.com/Wbaker7702/unstoppable-wallet-android/security/code-scanning/2)

In general: Add an explicit `permissions:` section to the workflow to restrict the default `GITHUB_TOKEN` privileges to the least required. This can be at the top level (applies to all jobs) or at the job level (applies only to that job).

Best fix here: Add a workflow-level `permissions:` block after the `name:` (or at the same indentation level as `on:` and `jobs:`) with `contents: read` as a minimal safe default, since the shown steps only need to read the repository. This avoids altering any existing job logic or steps.

Concretely: Edit `.github/workflows/ci-release.yml` to insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Android CI (release)`) and line 3 (`on:`). No imports or additional methods are required; it is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enhance security and reliability of the release process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->