### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -7,6 +7,8 @@ jobs:
   notify:
     if: ${{ !startsWith(github.head_ref, 'l10n_version/') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/unstoppable-wallet-android/security/code-scanning/1](https://github.com/Wbaker7702/unstoppable-wallet-android/security/code-scanning/1)

In general, to fix this class of problem you explicitly define a minimal `permissions:` block either at the workflow level (top of the file) or per job. This constrains the automatically provided `GITHUB_TOKEN` to only the scopes actually needed (often `contents: read` for CI jobs that only check out code).

For this specific workflow, the job only checks out code and sends a Telegram message using repository secrets; it does not write to the repository or to pull requests. Therefore, the minimal safe change is to add `permissions: contents: read`. Because there is only one job and the CodeQL warning is job-level, we can add `permissions:` under the `notify` job. Concretely, in `.github/workflows/ci-pull-request.yml`, insert:

```yaml
    permissions:
      contents: read
```

between `runs-on: ubuntu-latest` (line 9) and `steps:` (line 11). No additional imports or methods are required; it is purely a YAML configuration change and does not alter the existing job behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to refine permission scopes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->